### PR TITLE
Resolve bw2 2.4.5 incompatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
   entry_points:
     - activity-browser = activity_browser:run_activity_browser
 
@@ -24,7 +24,7 @@ requirements:
   run:
     - python >=3.8,<=3.11,!=3.10
     - arrow
-    - brightway2 >=2.4.4
+    - brightway2 =2.4.4
     - pyperclip
     - eidl >=2.0.1
     - libxml2 <=2.10.4


### PR DESCRIPTION
New bw2 `2.4.5` (specifically `bw2io=0.8.12`) is not compatible with AB right now. 

Will create proper fix for `AB=2.9.4`.

Sorry for all the mess <3

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
